### PR TITLE
Ignore nan / inf values

### DIFF
--- a/server/app/analyses/series.py
+++ b/server/app/analyses/series.py
@@ -51,14 +51,22 @@ class Series:
         }
 
     def update(self, steps: List[float], values: List[float]) -> None:
+        start_step = len(self.value)
         self.step += steps.copy()
         self.value += values.copy()
         self.last_step += steps.copy()
+        self._remove_nan(start_step)
 
         self.merge()
         while len(self) > MAX_BUFFER_LENGTH:
             self.step_gap *= 2
             self.merge()
+
+    def _remove_nan(self, start_step):
+        if len(self.value) == 0: return
+        for i in range(start_step, len(self.value)):
+            if not np.isfinite(self.value[i]):
+                self.value[i] = 0 if i == 0 else self.value[i - 1]
 
     def _find_gap(self) -> None:
         if self.step_gap:
@@ -184,5 +192,6 @@ class Series:
         self.step = data['step'].copy()
         self.last_step = data['last_step'].copy()
         self.value = data['value'].copy()
+        self._remove_nan(0)
 
         return self

--- a/server/app/analyses/series.py
+++ b/server/app/analyses/series.py
@@ -63,7 +63,6 @@ class Series:
             self.merge()
 
     def _remove_nan(self, start_step):
-        if len(self.value) == 0: return
         for i in range(start_step, len(self.value)):
             if not np.isfinite(self.value[i]):
                 self.value[i] = 0 if i == 0 else self.value[i - 1]


### PR DESCRIPTION
Currently, the API would return invalid JSON if the series contains inf / nan values, causing an infinite requesting loop in the webpage. Solved by replacing nan / inf values with the previous finite value or 0.